### PR TITLE
Parse remote address as `IpAddr` if `SocketAddr` failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT"
 [dependencies]
 governor = "0.3.1"
 lazy_static = "1.4.0"
-tide = "0.15.0"
+tide = "0.16.0"


### PR DESCRIPTION
`req.remote()` may return an IP address (such as `1.2.3.4`) instead of a socket address (such as `1.2.3.4:80`)